### PR TITLE
Update LWT version to 2.0.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,16 +2,16 @@ FROM alpine:3.13
 RUN apk update
 RUN apk upgrade
 RUN apk add php curl apache2 php7-apache2 php-mbstring
-RUN apk add  php7-mysqlnd php7-mysqli php7-curl php7-session php7-json
+RUN apk add php7-mysqlnd php7-mysqli php7-curl php7-session php7-json
 
 RUN mkdir -p /var/www/media && chmod -R 755 /var/www
-RUN wget https://sourceforge.net/projects/learning-with-texts/files/latest/download -O /var/www/lwt.zip
+RUN wget https://sourceforge.net/projects/learning-with-texts/files/learning_with_texts_2_0_3_complete.zip/download -O /var/www/lwt.zip
 
 WORKDIR /var/www/
 
 RUN unzip /var/www/lwt.zip
 RUN rm /var/www/*.txt
-RUN unzip /var/www/lwt_v_2_0_2.zip
+RUN unzip /var/www/lwt_v_2_0_3.zip
 RUN cp /var/www/connect_xampp.inc.php /var/www/connect.inc.php
 RUN sed -i 's/\$passwd = "";/\$passwd = getenv("MARIADB_ROOT_PASSWORD");/g' /var/www/connect.inc.php
 RUN sed -i 's/\$server = "localhost";/\$server = getenv("MARIADB_SERVER");/g' /var/www/connect.inc.php


### PR DESCRIPTION
- Use the latest version of LWT.
- Change the link to 2.0.3 instead of `latest` to avoid issues.