### PR TITLE
Add MariaDB user environment variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN rm /var/www/*.txt
 RUN unzip /var/www/lwt_v_2_0_2.zip
 RUN cp /var/www/connect_xampp.inc.php /var/www/connect.inc.php
 RUN sed -i 's/\$userid = "root";/\$userid = getenv("MARIADB_USER");/g' /var/www/connect.inc.php
-RUN sed -i 's/\$passwd = "";/\$passwd = getenv("MARIADB_ROOT_PASSWORD");/g' /var/www/connect.inc.php
+RUN sed -i 's/\$passwd = "";/\$passwd = getenv("MARIADB_PASSWORD");/g' /var/www/connect.inc.php
 RUN sed -i 's/\$server = "localhost";/\$server = getenv("MARIADB_SERVER");/g' /var/www/connect.inc.php
 
 ADD httpd.conf /etc/apache2/httpd.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN unzip /var/www/lwt.zip
 RUN rm /var/www/*.txt
 RUN unzip /var/www/lwt_v_2_0_2.zip
 RUN cp /var/www/connect_xampp.inc.php /var/www/connect.inc.php
+RUN sed -i 's/\$userid = "root";/\$userid = getenv("MARIADB_USER");/g' /var/www/connect.inc.php
 RUN sed -i 's/\$passwd = "";/\$passwd = getenv("MARIADB_ROOT_PASSWORD");/g' /var/www/connect.inc.php
 RUN sed -i 's/\$server = "localhost";/\$server = getenv("MARIADB_SERVER");/g' /var/www/connect.inc.php
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ services:
     image: mariadb:10.6
     restart: always
     environment:
-      - "MARIADB_ROOT_PASSWORD=qwerty"
+      - "MARIADB_USER=lwt"
+      - "MARIADB_PASSWORD=qwerty"
     volumes:
       - media/:/var/lib/mysql
   lwt:
@@ -26,7 +27,8 @@ services:
     restart: always
     environment:
       - "MARIADB_SERVER=mariadb"
-      - "MARIADB_ROOT_PASSWORD=qwerty"
+      - "MARIADB_USER=lwt"
+      - "MARIADB_PASSWORD=qwerty"
     ports:
       - "8080:80"
     depends_on:
@@ -36,6 +38,6 @@ services:
 You can also probably run it with docker-run like the following
 
 ```shell
-docker run -d --port "80:8080" --link mariadb_container -e MARIADB_SERVER=db -e MARIADB_ROOT_PASSWORD=qwerty lwt
+docker run -d --port "80:8080" --link mariadb_container -e MARIADB_SERVER=db -e MARIADB_USER=lwt -e MARIADB_PASSWORD=qwerty lwt
 ```
 


### PR DESCRIPTION
Add the option to set the `userid` to access MariaDB, so one can avoid using root if desired.